### PR TITLE
Turn `Grade.date` type from `str` to `datetime.date`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,6 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -e '.[test]'
-    - name: Run tests
+    - name: Check if everything is ready to ship
       run: |
-        pytest
+        make ready

--- a/axios/__main__.py
+++ b/axios/__main__.py
@@ -1,4 +1,4 @@
-from .cli import cli, defaults
+from .cli import cli
 
 if __name__ == "__main__":
     cli(auto_envvar_prefix="AXIOS")

--- a/axios/cli.py
+++ b/axios/cli.py
@@ -30,8 +30,7 @@ today = datetime.date.today()
 )
 @click.option(
     "--output-format",
-    type=click.Choice(['json', 'ndjson', 'text'],
-    case_sensitive=False),
+    type=click.Choice(["json", "ndjson", "text"], case_sensitive=False),
     default="text",
 )
 @click.option(

--- a/axios/models.py
+++ b/axios/models.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import date
 
 
 @dataclass
@@ -17,8 +18,8 @@ class Profile(object):
 
 
 @dataclass
-class Grade(object):
-    date: str
+class Grade:
+    date: date
     subject: str
     kind: str
     value: str

--- a/axios/navigator.py
+++ b/axios/navigator.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 from typing import Any, List
 
 import requests
@@ -155,7 +155,9 @@ class Navigator:
         for row in rows:
             grades.append(
                 Grade(
-                    date=first(row.xpath("td[1]/text()")),
+                    date=datetime.strptime(
+                        first(row.xpath("td[1]/text()")), "%d/%m/%Y"
+                    ),
                     subject=first(row.xpath("td[2]/text()")),
                     kind=first(row.xpath("td[3]/text()")),
                     value=first(row.xpath("td[4]/span/text()")),

--- a/axios/navigator.py
+++ b/axios/navigator.py
@@ -43,7 +43,6 @@ class Navigator:
         self,
         credentials: Credentials,
         student_id: str,
-        session: requests.Session = requests.Session(),
         verbose: bool = False,
     ):
         self.credentials = credentials
@@ -52,7 +51,7 @@ class Navigator:
             period="FT01" if 9 < today.month < 2 else "FT02",
             student_id=student_id,
         )
-        self.session = session
+        self.session = requests.Session()
         self.verbose = verbose
 
     def login(self) -> Profile:
@@ -173,9 +172,9 @@ class Navigator:
         """Select the student"""
         self.state.student_id = student_id
 
-    def select_year(self, year: int, day=date.today()) -> None:
+    def select_year(self, year: int, day=None) -> None:
         """Select the year"""
-
+        day = day or date.today()
         if self.state.year == year:
             if self.verbose:
                 print(

--- a/axios/result.py
+++ b/axios/result.py
@@ -45,8 +45,7 @@ class GradesListResult:
 
         for g in self.grades:
             table.add_row(
-                # str(g.date.strftime("%Y-%m-%d")),
-                str(g.date.strftime("%d/%m/%Y")),
+                str(g.date.strftime("%Y-%m-%d")),
                 str(g.subject),
                 str(g.kind),
                 str(g.value),

--- a/axios/result.py
+++ b/axios/result.py
@@ -1,4 +1,4 @@
-import dataclasses
+import datetime
 import io
 import json
 from typing import Any, List
@@ -22,8 +22,15 @@ def render(result: Any, output_format: str = "text") -> str:
         raise ValueError("Unknown format: " + output_format)
 
 
+class DateTimeEncoder(json.JSONEncoder):
+    """JSON encoder for object containing datetime values."""
+
+    def default(self, obj):
+        if isinstance(obj, (datetime.date, datetime.datetime)):
+            return obj.isoformat()
+
+
 class GradesListResult:
-    
     def __init__(self, grades: List[Grade]) -> None:
         self.grades = grades
 
@@ -38,7 +45,8 @@ class GradesListResult:
 
         for g in self.grades:
             table.add_row(
-                str(g.date),
+                # str(g.date.strftime("%Y-%m-%d")),
+                str(g.date.strftime("%d/%m/%Y")),
                 str(g.subject),
                 str(g.kind),
                 str(g.value),
@@ -56,7 +64,11 @@ class GradesListResult:
         return output.getvalue()
 
     def json(self) -> str:
-        return json.dumps([g.__dict__ for g in self.grades])
+        return json.dumps(
+            [g.__dict__ for g in self.grades], cls=DateTimeEncoder
+        )
 
     def ndjson(self) -> str:
-        return "\n".join([json.dumps(g.__dict__) for g in self.grades])
+        return "\n".join(
+            [json.dumps(g.__dict__, cls=DateTimeEncoder) for g in self.grades],
+        )

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
             "types-Pygments",
             "types-requests",
             "types-setuptools",
+            "urllib3<2",
         ]
     },
     python_requires=">=3.8",

--- a/tests/test_axios.py
+++ b/tests/test_axios.py
@@ -59,36 +59,36 @@ def test_list_grades():
                                                                                 
   Data         Materia         Tipo      Voto   Commento         Docente        
  ────────────────────────────────────────────────────────────────────────────── 
-  31/01/2023   ARTE E          Grafico   10     Pittura          Pagliarulo     
+  2023-01-31   ARTE E          Grafico   10     Pittura          Pagliarulo     
                IMMAGINE                         rupestre         Veronica       
-  27/01/2023   SCIENZE         Pratico   8      IMPEGNO E        Vogliotti      
+  2023-01-27   SCIENZE         Pratico   8      IMPEGNO E        Vogliotti      
                MOTORIE E                        PARTECIPAZIONE   Enzo           
                SPORTIVE                                                         
-  27/01/2023   SCIENZE         Pratico   7      VALUTAZIONE      Vogliotti      
+  2023-01-27   SCIENZE         Pratico   7      VALUTAZIONE      Vogliotti      
                MOTORIE E                        TEST FISICI      Enzo           
                SPORTIVE                         ATTITUDINALI                    
-  26/01/2023   MUSICA          Pratico   7.5    Verifica di      Cataldo        
+  2023-01-26   MUSICA          Pratico   7.5    Verifica di      Cataldo        
                                                 carattere        Francesco      
                                                 pratico.                        
-  25/01/2023   STORIA          Orale     9                       Novelli        
+  2023-01-25   STORIA          Orale     9                       Novelli        
                                                                  Cristina       
-  25/01/2023   TECNOLOGIA e    Scritto   8                       Pavarin Maria  
+  2023-01-25   TECNOLOGIA e    Scritto   8                       Pavarin Maria  
                INFORMATICA                                       Luisa          
-  24/01/2023   SCIENZE         Scritto   9      Verifica         Micela Silvia  
+  2023-01-24   SCIENZE         Scritto   9      Verifica         Micela Silvia  
                                                 scritta                         
                                                 sull'organizz…                  
                                                 dei viventi                     
-  23/01/2023   RELIGIONE       Orale     7                       Avanzato       
+  2023-01-23   RELIGIONE       Orale     7                       Avanzato       
                                                                  Paola Carla    
-  20/01/2023   ITALIANO        Orale     7.5    Presentazione    Rapalino Lara  
+  2023-01-20   ITALIANO        Orale     7.5    Presentazione    Rapalino Lara  
                                                 libro                           
-  19/01/2023   EDUCAZIONE      Scritto   8,5    Verifica di      Micela Silvia  
+  2023-01-19   EDUCAZIONE      Scritto   8,5    Verifica di      Micela Silvia  
                CIVICA                           educazione                      
                                                 civica di                       
                                                 italiano sulla                  
                                                 comprensione                    
                                                 del testo                       
-  19/01/2023   ITALIANO        Scritto   8.5    Verifica di      Rapalino Lara  
+  2023-01-19   ITALIANO        Scritto   8.5    Verifica di      Rapalino Lara  
                                                 Educazione                      
                                                 Civica (il                      
                                                 voto fa media                   
@@ -102,114 +102,114 @@ def test_list_grades():
                                                 animali                         
                                                 (comprensione                   
                                                 del testo)                      
-  18/01/2023   LINGUA          Scritto   9,75   Verifica units   Barbero        
+  2023-01-18   LINGUA          Scritto   9,75   Verifica units   Barbero        
                STRANIERA                        3-4              Daniela        
                INGLESE                                                          
-  17/01/2023   ITALIANO        Scritto   9+     Grammatica:      Rapalino Lara  
+  2023-01-17   ITALIANO        Scritto   9+     Grammatica:      Rapalino Lara  
                                                 l'articolo                      
-  16/01/2023   STORIA          Scritto   7.7                     Novelli        
+  2023-01-16   STORIA          Scritto   7.7                     Novelli        
                                                                  Cristina       
-  13/01/2023   MATEMATICA      Scritto   8,75   Verifica         Micela Silvia  
+  2023-01-13   MATEMATICA      Scritto   8,75   Verifica         Micela Silvia  
                                                 scritta sui                     
                                                 numeri                          
                                                 naturali e                      
                                                 decimali                        
-  12/01/2023   ARTE E          Grafico   8      Paesaggio        Pagliarulo     
+  2023-01-12   ARTE E          Grafico   8      Paesaggio        Pagliarulo     
                IMMAGINE                                          Veronica       
-  12/01/2023   ARTE E          Grafico   9      Colori caldi e   Pagliarulo     
+  2023-01-12   ARTE E          Grafico   9      Colori caldi e   Pagliarulo     
                IMMAGINE                         freddi           Veronica       
-  11/01/2023   STORIA          Scritto   7.3                     Novelli        
+  2023-01-11   STORIA          Scritto   7.3                     Novelli        
                                                                  Cristina       
-  10/01/2023   EDUCAZIONE      Scritto   7,5    Verifica         Micela Silvia  
+  2023-01-10   EDUCAZIONE      Scritto   7,5    Verifica         Micela Silvia  
                CIVICA                           scritta di                      
                                                 educazione                      
                                                 civica -                        
                                                 Tecnologia                      
-  23/12/2022   LINGUA          Scritto   8      Da risentire     Giovannini     
+  2022-12-23   LINGUA          Scritto   8      Da risentire     Giovannini     
                STRANIERA                        sul verbo        Sonia          
                FRANCESE                         essere.                         
-  23/12/2022   ITALIANO        Scritto   6.5    Tema in classe   Rapalino Lara  
-  22/12/2022   LINGUA          Orale     8,5    Interrogazione   Barbero        
+  2022-12-23   ITALIANO        Scritto   6.5    Tema in classe   Rapalino Lara  
+  2022-12-22   LINGUA          Orale     8,5    Interrogazione   Barbero        
                STRANIERA                                         Daniela        
                INGLESE                                                          
-  21/12/2022   SCIENZE         Scritto   8      Verifica         Micela Silvia  
+  2022-12-21   SCIENZE         Scritto   8      Verifica         Micela Silvia  
                                                 scritta sugli                   
                                                 stati di                        
                                                 aggregazione e                  
                                                 i passaggi di                   
                                                 stato                           
-  19/12/2022   ITALIANO        Scritto   8-     La favola:       Rapalino Lara  
+  2022-12-19   ITALIANO        Scritto   8-     La favola:       Rapalino Lara  
                                                 comprensione                    
                                                 del testo e                     
                                                 verifica delle                  
                                                 conoscenze                      
-  15/12/2022   SCIENZE         Pratico   8      Verifica         Vogliotti      
+  2022-12-15   SCIENZE         Pratico   8      Verifica         Vogliotti      
                MOTORIE E                        intermedia       Enzo           
                SPORTIVE                         test di                         
                                                 resistenza:                     
                                                 Cooper (6                       
                                                 minuti)                         
-  13/12/2022   TECNOLOGIA e    Grafico   7                       Pavarin Maria  
+  2022-12-13   TECNOLOGIA e    Grafico   7                       Pavarin Maria  
                INFORMATICA                                       Luisa          
-  12/12/2022   GEOGRAFIA       Scritto   6.7                     Novelli        
+  2022-12-12   GEOGRAFIA       Scritto   6.7                     Novelli        
                                                                  Cristina       
-  06/12/2022   TECNOLOGIA e    Scritto   7.5                     Pavarin Maria  
+  2022-12-06   TECNOLOGIA e    Scritto   7.5                     Pavarin Maria  
                INFORMATICA                                       Luisa          
-  05/12/2022   RELIGIONE       Orale     8.5    VALUTAZIONE      Avanzato       
+  2022-12-05   RELIGIONE       Orale     8.5    VALUTAZIONE      Avanzato       
                                                 PARTECIPAZIONE   Paola Carla    
-  02/12/2022   MATEMATICA      Scritto   7,75   Verifica sugli   Micela Silvia  
+  2022-12-02   MATEMATICA      Scritto   7,75   Verifica sugli   Micela Silvia  
                                                 insiemi                         
-  01/12/2022   ARTE E          Grafico   10     Tav.3 figura e   Pagliarulo     
+  2022-12-01   ARTE E          Grafico   10     Tav.3 figura e   Pagliarulo     
                IMMAGINE                         sfondo           Veronica       
-  01/12/2022   ARTE E          Grafico   7/8    Tav.1 Punto e    Pagliarulo     
+  2022-12-01   ARTE E          Grafico   7/8    Tav.1 Punto e    Pagliarulo     
                IMMAGINE                         linea            Veronica       
-  30/11/2022   MUSICA          Orale     7      Verifica di      Cataldo        
+  2022-11-30   MUSICA          Orale     7      Verifica di      Cataldo        
                                                 carattere        Francesco      
                                                 teorico.                        
                                                 Interrogazione                  
                                                 su tutto il                     
                                                 programma                       
                                                 svolto finora.                  
-  24/11/2022   ITALIANO        Scritto   8.5    Fonologia e      Rapalino Lara  
+  2022-11-24   ITALIANO        Scritto   8.5    Fonologia e      Rapalino Lara  
                                                 ortografia                      
-  23/11/2022   TECNOLOGIA e    Grafico   6.5                     Pavarin Maria  
+  2022-11-23   TECNOLOGIA e    Grafico   6.5                     Pavarin Maria  
                INFORMATICA                                       Luisa          
-  23/11/2022   MUSICA          Orale     7,5    Verifica di      Cataldo        
+  2022-11-23   MUSICA          Orale     7,5    Verifica di      Cataldo        
                                                 carattere        Francesco      
                                                 teorico.                        
                                                 Interrogazione                  
                                                 su tutto il                     
                                                 programma                       
                                                 svolto finora.                  
-  18/11/2022   MATEMATICA      Grafico   8,5    Verifica sulle   Micela Silvia  
+  2022-11-18   MATEMATICA      Grafico   8,5    Verifica sulle   Micela Silvia  
                                                 equivalenze e                   
                                                 le operazioni                   
                                                 con le misure                   
                                                 del tempo                       
-  16/11/2022   TECNOLOGIA e    Grafico   7                       Pavarin Maria  
+  2022-11-16   TECNOLOGIA e    Grafico   7                       Pavarin Maria  
                INFORMATICA                                       Luisa          
-  10/11/2022   ARTE E          Grafico   8      Poster per la    Pagliarulo     
+  2022-11-10   ARTE E          Grafico   8      Poster per la    Pagliarulo     
                IMMAGINE                         pace             Veronica       
-  09/11/2022   LINGUA          Scritto   8,5    Test units 1 e   Barbero        
+  2022-11-09   LINGUA          Scritto   8,5    Test units 1 e   Barbero        
                STRANIERA                        2                Daniela        
                INGLESE                                                          
-  08/11/2022   LINGUA          Scritto   8      Verifica unità   Giovannini     
+  2022-11-08   LINGUA          Scritto   8      Verifica unità   Giovannini     
                STRANIERA                        1                Sonia          
                FRANCESE                                                         
-  28/10/2022   MATEMATICA      Scritto   8,5    Verifica di      Micela Silvia  
+  2022-10-28   MATEMATICA      Scritto   8,5    Verifica di      Micela Silvia  
                                                 aritmetica                      
                                                 sulle                           
                                                 rappresentazi…                  
                                                 grafiche                        
-  26/10/2022   ITALIANO        Orale     7.5    La leggenda      Rapalino Lara  
-  25/10/2022   SCIENZE         Scritto   7,75                    Micela Silvia  
-  24/10/2022   ITALIANO        Scritto   8.5    Prova di         Rapalino Lara  
+  2022-10-26   ITALIANO        Orale     7.5    La leggenda      Rapalino Lara  
+  2022-10-25   SCIENZE         Scritto   7,75                    Micela Silvia  
+  2022-10-24   ITALIANO        Scritto   8.5    Prova di         Rapalino Lara  
                                                 comprensione                    
                                                 del testo                       
-  20/10/2022   LINGUA          Scritto   9,5    Verifica unit    Barbero        
+  2022-10-20   LINGUA          Scritto   9,5    Verifica unit    Barbero        
                STRANIERA                        1                Daniela        
                INGLESE                                                          
-  20/10/2022   MUSICA          Pratico   6,5    Verifica di      Cataldo        
+  2022-10-20   MUSICA          Pratico   6,5    Verifica di      Cataldo        
                                                 carattere        Francesco      
                                                 pratico.                        
                                                 Conoscenza                      
@@ -221,16 +221,16 @@ def test_list_grades():
                                                 strumento,                      
                                                 qualità del                     
                                                 suono.                          
-  19/10/2022   SCIENZE         Pratico   7      Valutazione      Vogliotti      
+  2022-10-19   SCIENZE         Pratico   7      Valutazione      Vogliotti      
                MOTORIE E                        test fisici      Enzo           
                SPORTIVE                         attitudinali                    
-  18/10/2022   LINGUA          Orale     8      Interrogazione   Giovannini     
+  2022-10-18   LINGUA          Orale     8      Interrogazione   Giovannini     
                STRANIERA                        u1 fino alle     Sonia          
                FRANCESE                         materie                         
                                                 scolastiche                     
-  17/10/2022   STORIA          Scritto   8.3                     Novelli        
+  2022-10-17   STORIA          Scritto   8.3                     Novelli        
                                                                  Cristina       
-  26/09/2022   STORIA          Orale     8                       Novelli        
+  2022-09-26   STORIA          Orale     8                       Novelli        
                                                                  Cristina       
                                                                                 
 

--- a/tests/test_axios.py
+++ b/tests/test_axios.py
@@ -243,11 +243,13 @@ def test_list_grades():
 def test_grades_list_json():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["--output-format", "json", "grades", "list"], env=env)
+        result = runner.invoke(
+            cli, ["--output-format", "json", "grades", "list"], env=env
+        )
         with open("/tmp/sample.txt", "w") as f:
             f.write(result.output)
 
-        expected = '[{"date": "20/03/2023", "subject": "STORIA", "kind": "Orale", "value": "10", "teacher": "Novelli Cristina", "comment": ""}, {"date": "17/03/2023", "subject": "ITALIANO", "kind": "Orale", "value": "8", "teacher": "Rapalino Lara", "comment": "Presentazione orale del libro letto"}, {"date": "16/03/2023", "subject": "LINGUA STRANIERA INGLESE", "kind": "Scritto", "value": "8,25", "teacher": "Barbero Daniela", "comment": "Verifica units 5-6"}, {"date": "15/03/2023", "subject": "TECNOLOGIA e INFORMATICA", "kind": "Grafico", "value": "8", "teacher": "Pavarin Maria Luisa", "comment": ""}, {"date": "08/03/2023", "subject": "ITALIANO", "kind": "Scritto", "value": "8.5", "teacher": "Rapalino Lara", "comment": "Epica: epica omerica e Iliade"}, {"date": "08/03/2023", "subject": "TECNOLOGIA e INFORMATICA", "kind": "Grafico", "value": "8.5", "teacher": "Pavarin Maria Luisa", "comment": ""}, {"date": "06/03/2023", "subject": "ITALIANO", "kind": "Orale", "value": "8", "teacher": "Rapalino Lara", "comment": "La fiaba"}, {"date": "02/03/2023", "subject": "SCIENZE", "kind": "Scritto", "value": "8,75", "teacher": "Micela Silvia", "comment": ""}, {"date": "22/02/2023", "subject": "GEOGRAFIA", "kind": "Orale", "value": "7.75", "teacher": "Gardello Martina", "comment": ""}, {"date": "17/02/2023", "subject": "MATEMATICA", "kind": "Scritto", "value": "9", "teacher": "Micela Silvia", "comment": "Verifica scritta di aritmetica sulle quattro operazioni e le loro propriet\\u00e0."}, {"date": "16/02/2023", "subject": "MUSICA", "kind": "Scritto", "value": "6", "teacher": "Cataldo Francesco", "comment": "Verifica scritta di carattere teorico."}, {"date": "16/02/2023", "subject": "ARTE E IMMAGINE", "kind": "Grafico", "value": "9", "teacher": "Pagliarulo Veronica", "comment": "Arte egizia"}, {"date": "15/02/2023", "subject": "TECNOLOGIA e INFORMATICA", "kind": "Scritto", "value": "8.75", "teacher": "Pavarin Maria Luisa", "comment": ""}, {"date": "07/02/2023", "subject": "LINGUA STRANIERA FRANCESE", "kind": "Scritto", "value": "8", "teacher": "Giovannini Sonia", "comment": "Verifica Unit\\u00e9 3"}]\n'
+        expected = '[{"date": "2023-03-20T00:00:00", "subject": "STORIA", "kind": "Orale", "value": "10", "teacher": "Novelli Cristina", "comment": ""}, {"date": "2023-03-17T00:00:00", "subject": "ITALIANO", "kind": "Orale", "value": "8", "teacher": "Rapalino Lara", "comment": "Presentazione orale del libro letto"}, {"date": "2023-03-16T00:00:00", "subject": "LINGUA STRANIERA INGLESE", "kind": "Scritto", "value": "8,25", "teacher": "Barbero Daniela", "comment": "Verifica units 5-6"}, {"date": "2023-03-15T00:00:00", "subject": "TECNOLOGIA e INFORMATICA", "kind": "Grafico", "value": "8", "teacher": "Pavarin Maria Luisa", "comment": ""}, {"date": "2023-03-08T00:00:00", "subject": "ITALIANO", "kind": "Scritto", "value": "8.5", "teacher": "Rapalino Lara", "comment": "Epica: epica omerica e Iliade"}, {"date": "2023-03-08T00:00:00", "subject": "TECNOLOGIA e INFORMATICA", "kind": "Grafico", "value": "8.5", "teacher": "Pavarin Maria Luisa", "comment": ""}, {"date": "2023-03-06T00:00:00", "subject": "ITALIANO", "kind": "Orale", "value": "8", "teacher": "Rapalino Lara", "comment": "La fiaba"}, {"date": "2023-03-02T00:00:00", "subject": "SCIENZE", "kind": "Scritto", "value": "8,75", "teacher": "Micela Silvia", "comment": ""}, {"date": "2023-02-22T00:00:00", "subject": "GEOGRAFIA", "kind": "Orale", "value": "7.75", "teacher": "Gardello Martina", "comment": ""}, {"date": "2023-02-17T00:00:00", "subject": "MATEMATICA", "kind": "Scritto", "value": "9", "teacher": "Micela Silvia", "comment": "Verifica scritta di aritmetica sulle quattro operazioni e le loro propriet\\u00e0."}, {"date": "2023-02-16T00:00:00", "subject": "MUSICA", "kind": "Scritto", "value": "6", "teacher": "Cataldo Francesco", "comment": "Verifica scritta di carattere teorico."}, {"date": "2023-02-16T00:00:00", "subject": "ARTE E IMMAGINE", "kind": "Grafico", "value": "9", "teacher": "Pagliarulo Veronica", "comment": "Arte egizia"}, {"date": "2023-02-15T00:00:00", "subject": "TECNOLOGIA e INFORMATICA", "kind": "Scritto", "value": "8.75", "teacher": "Pavarin Maria Luisa", "comment": ""}, {"date": "2023-02-07T00:00:00", "subject": "LINGUA STRANIERA FRANCESE", "kind": "Scritto", "value": "8", "teacher": "Giovannini Sonia", "comment": "Verifica Unit\\u00e9 3"}]\n'
 
         assert result.exit_code == 0, result.output
         assert result.output == expected
@@ -258,25 +260,27 @@ def test_grades_list_json():
 def test_grades_list_ndjson():
     runner = CliRunner()
     with runner.isolated_filesystem():
-        result = runner.invoke(cli, ["--output-format", "ndjson", "grades", "list"], env=env)
+        result = runner.invoke(
+            cli, ["--output-format", "ndjson", "grades", "list"], env=env
+        )
         with open("/tmp/sample.txt", "w") as f:
             f.write(result.output)
 
-        expected = """{"date": "23/03/2023", "subject": "ARTE E IMMAGINE", "kind": "Grafico", "value": "9", "teacher": "Pagliarulo Veronica", "comment": "Concorso LAV"}
-{"date": "20/03/2023", "subject": "STORIA", "kind": "Orale", "value": "10", "teacher": "Novelli Cristina", "comment": ""}
-{"date": "17/03/2023", "subject": "ITALIANO", "kind": "Orale", "value": "8", "teacher": "Rapalino Lara", "comment": "Presentazione orale del libro letto"}
-{"date": "16/03/2023", "subject": "LINGUA STRANIERA INGLESE", "kind": "Scritto", "value": "8,25", "teacher": "Barbero Daniela", "comment": "Verifica units 5-6"}
-{"date": "15/03/2023", "subject": "TECNOLOGIA e INFORMATICA", "kind": "Grafico", "value": "8", "teacher": "Pavarin Maria Luisa", "comment": ""}
-{"date": "08/03/2023", "subject": "ITALIANO", "kind": "Scritto", "value": "8.5", "teacher": "Rapalino Lara", "comment": "Epica: epica omerica e Iliade"}
-{"date": "08/03/2023", "subject": "TECNOLOGIA e INFORMATICA", "kind": "Grafico", "value": "8.5", "teacher": "Pavarin Maria Luisa", "comment": ""}
-{"date": "06/03/2023", "subject": "ITALIANO", "kind": "Orale", "value": "8", "teacher": "Rapalino Lara", "comment": "La fiaba"}
-{"date": "02/03/2023", "subject": "SCIENZE", "kind": "Scritto", "value": "8,75", "teacher": "Micela Silvia", "comment": ""}
-{"date": "22/02/2023", "subject": "GEOGRAFIA", "kind": "Orale", "value": "7.75", "teacher": "Gardello Martina", "comment": ""}
-{"date": "17/02/2023", "subject": "MATEMATICA", "kind": "Scritto", "value": "9", "teacher": "Micela Silvia", "comment": "Verifica scritta di aritmetica sulle quattro operazioni e le loro propriet\\u00e0."}
-{"date": "16/02/2023", "subject": "MUSICA", "kind": "Scritto", "value": "6", "teacher": "Cataldo Francesco", "comment": "Verifica scritta di carattere teorico."}
-{"date": "16/02/2023", "subject": "ARTE E IMMAGINE", "kind": "Grafico", "value": "9", "teacher": "Pagliarulo Veronica", "comment": "Arte egizia"}
-{"date": "15/02/2023", "subject": "TECNOLOGIA e INFORMATICA", "kind": "Scritto", "value": "8.75", "teacher": "Pavarin Maria Luisa", "comment": ""}
-{"date": "07/02/2023", "subject": "LINGUA STRANIERA FRANCESE", "kind": "Scritto", "value": "8", "teacher": "Giovannini Sonia", "comment": "Verifica Unit\\u00e9 3"}
+        expected = """{"date": "2023-03-23T00:00:00", "subject": "ARTE E IMMAGINE", "kind": "Grafico", "value": "9", "teacher": "Pagliarulo Veronica", "comment": "Concorso LAV"}
+{"date": "2023-03-20T00:00:00", "subject": "STORIA", "kind": "Orale", "value": "10", "teacher": "Novelli Cristina", "comment": ""}
+{"date": "2023-03-17T00:00:00", "subject": "ITALIANO", "kind": "Orale", "value": "8", "teacher": "Rapalino Lara", "comment": "Presentazione orale del libro letto"}
+{"date": "2023-03-16T00:00:00", "subject": "LINGUA STRANIERA INGLESE", "kind": "Scritto", "value": "8,25", "teacher": "Barbero Daniela", "comment": "Verifica units 5-6"}
+{"date": "2023-03-15T00:00:00", "subject": "TECNOLOGIA e INFORMATICA", "kind": "Grafico", "value": "8", "teacher": "Pavarin Maria Luisa", "comment": ""}
+{"date": "2023-03-08T00:00:00", "subject": "ITALIANO", "kind": "Scritto", "value": "8.5", "teacher": "Rapalino Lara", "comment": "Epica: epica omerica e Iliade"}
+{"date": "2023-03-08T00:00:00", "subject": "TECNOLOGIA e INFORMATICA", "kind": "Grafico", "value": "8.5", "teacher": "Pavarin Maria Luisa", "comment": ""}
+{"date": "2023-03-06T00:00:00", "subject": "ITALIANO", "kind": "Orale", "value": "8", "teacher": "Rapalino Lara", "comment": "La fiaba"}
+{"date": "2023-03-02T00:00:00", "subject": "SCIENZE", "kind": "Scritto", "value": "8,75", "teacher": "Micela Silvia", "comment": ""}
+{"date": "2023-02-22T00:00:00", "subject": "GEOGRAFIA", "kind": "Orale", "value": "7.75", "teacher": "Gardello Martina", "comment": ""}
+{"date": "2023-02-17T00:00:00", "subject": "MATEMATICA", "kind": "Scritto", "value": "9", "teacher": "Micela Silvia", "comment": "Verifica scritta di aritmetica sulle quattro operazioni e le loro propriet\\u00e0."}
+{"date": "2023-02-16T00:00:00", "subject": "MUSICA", "kind": "Scritto", "value": "6", "teacher": "Cataldo Francesco", "comment": "Verifica scritta di carattere teorico."}
+{"date": "2023-02-16T00:00:00", "subject": "ARTE E IMMAGINE", "kind": "Grafico", "value": "9", "teacher": "Pagliarulo Veronica", "comment": "Arte egizia"}
+{"date": "2023-02-15T00:00:00", "subject": "TECNOLOGIA e INFORMATICA", "kind": "Scritto", "value": "8.75", "teacher": "Pavarin Maria Luisa", "comment": ""}
+{"date": "2023-02-07T00:00:00", "subject": "LINGUA STRANIERA FRANCESE", "kind": "Scritto", "value": "8", "teacher": "Giovannini Sonia", "comment": "Verifica Unit\\u00e9 3"}
 """
 
         assert result.exit_code == 0, result.output

--- a/tests/test_axios.py
+++ b/tests/test_axios.py
@@ -234,7 +234,7 @@ def test_list_grades():
                                                                  Cristina       
                                                                                 
 
-"""
+"""  # noqa: W291 W293
         )
 
 


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Using the `str` value with the `"%d/%m/%Y"` format in the model makes harder to use the data downstream.

### Change description
<!-- What does your code do? -->

We are changing the `date` attribute in the `Grade` model from `str` to `datetime.date`; dates formatting in the JSON-based representation will use the ISO format.



### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are appropriately filled.
* [x] Changes will be merged in `main.`
* [x] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [x] Docs are updated (at least the `README.md`, if needed).
* [x] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well-formatted.